### PR TITLE
Fix responsive logo text visibility

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -297,7 +297,7 @@ function App() {
                 alt="Union Law Firm Logo"
                 className="h-10 w-auto mr-2"
               />
-              <span className="text-white font-semibold text-lg hidden sm:inline">Union Law Firm</span>
+              <span className="block sm:inline text-white font-semibold text-sm sm:text-lg">Union Law Firm</span>
             </button>
           </div>
           


### PR DESCRIPTION
## Summary
- ensure logo text shows on small screens with smaller font

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687e0812488883229d7a90ccddbbc653