### PR TITLE
Remove Emergent badge from UI

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -76,6 +76,14 @@ function App() {
   useEffect(() => {
     AOS.init({ duration: 800 });
   }, []);
+
+  // Remove Emergent badge injected via index.html if present
+  useEffect(() => {
+    const badge = document.getElementById('emergent-badge');
+    if (badge) {
+      badge.remove();
+    }
+  }, []);
   
   // Set document direction based on language
   useEffect(() => {


### PR DESCRIPTION
## Summary
- strip the Emergent badge injected into index.html when App mounts

## Testing
- `npm --prefix frontend test`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687e081d22c483228c192e9e4215f9d7