### PR TITLE
Add Supabase client module

### DIFF
--- a/frontend/src/lib/supabase.js
+++ b/frontend/src/lib/supabase.js
@@ -1,0 +1,16 @@
+// Import the Supabase client factory
+import { createClient } from '@supabase/supabase-js';
+
+// Retrieve environment variables for Supabase
+// These should be defined in your .env file at the project root
+// Example:
+// SUPABASE_URL=https://your-project.supabase.co
+// SUPABASE_ANON_KEY=your-anon-key
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
+
+// Initialize the Supabase client
+const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+// Export the client so it can be imported in other files
+export default supabase;


### PR DESCRIPTION
## Summary
- add `frontend/src/lib/supabase.js` to initialize Supabase

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68809ed31b688322926f1b41bc99d832