### PR TITLE
Improve register signUp data

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1517,6 +1517,12 @@ function App() {
         const { data, error } = await supabase.auth.signUp({
           email: registerFormData.email,
           password: registerFormData.password,
+          options: {
+            data: {
+              full_name: registerFormData.name,
+              ...(registerFormData.phone && { phone: registerFormData.phone }),
+            },
+          },
         });
 
         if (error) {


### PR DESCRIPTION
## Summary
- send full name and phone to Supabase signUp

## Testing
- `npm test --silent`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688bcb984a5c83229fa7a26259b6861f