### PR TITLE
Fix signup error message

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1526,9 +1526,14 @@ function App() {
         });
 
         if (error) {
-          setRegisterError(error.message || t('auth.loginError'));
+          console.error('Sign up error:', error.message, data);
+          if (error.message && error.message.toLowerCase().includes('already')) {
+            setRegisterError('Un compte avec cet email existe déjà');
+          } else {
+            setRegisterError(error.message || t('auth.loginError'));
+          }
         } else {
-          if (data.session) {
+          if (data && data.session) {
             localStorage.setItem('token', data.session.access_token);
             setToken(data.session.access_token);
           }
@@ -1537,6 +1542,7 @@ function App() {
           setCurrentPage('dashboard');
         }
       } catch (err) {
+        console.error('Unexpected sign up error:', err);
         setRegisterError(t('auth.loginError'));
       } finally {
         setRegisterLoading(false);


### PR DESCRIPTION
## Summary
- improve signup error handling in `renderRegister`
- clarify duplicate-email case and log unexpected errors

## Testing
- `npm test --silent` *(fails: No tests found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_688c6aa4c2288322a7784fe8aea844bb