### PR TITLE
fix: ensure supabase env vars load in CRA

### DIFF
--- a/frontend/src/lib/supabase.js
+++ b/frontend/src/lib/supabase.js
@@ -2,45 +2,29 @@
 import { createClient } from "@supabase/supabase-js";
 
 /**
- * Helper to retrieve environment variables regardless of the bundler or
- * execution context. It checks `import.meta.env`, `process.env` and any
- * variables attached to `globalThis` (useful in certain server setups).
+ * Collect all available environment variables into a single object.
+ *
+ * `process.env` is inlined by bundlers such as Create React App/webpack, so we
+ * grab it once here and then perform dynamic lookups on the resulting object.
+ * This avoids relying on a runtime `process` polyfill, which is often missing
+ * in browser builds and was the reason variables appeared as `undefined`.
  */
-function getEnvVar(...keys) {
-  for (const key of keys) {
-    if (
-      typeof import.meta !== "undefined" &&
-      import.meta.env &&
-      import.meta.env[key]
-    ) {
-      return import.meta.env[key];
-    }
-    if (typeof process !== "undefined" && process.env && process.env[key]) {
-      return process.env[key];
-    }
-    if (
-      typeof globalThis !== "undefined" &&
-      globalThis.env &&
-      globalThis.env[key]
-    ) {
-      return globalThis.env[key];
-    }
-  }
-  return undefined;
-}
+const ENV = {
+  ...(typeof import.meta !== "undefined" && import.meta.env
+    ? import.meta.env
+    : {}),
+  ...(typeof process !== "undefined" && process.env ? process.env : {}),
+  ...(typeof globalThis !== "undefined" && globalThis.env ? globalThis.env : {}),
+};
 
 // Attempt to retrieve variables using multiple possible prefixes so it works
 // with Create React App (REACT_APP_), Vite (VITE_) and generic names
-const supabaseUrl = getEnvVar(
-  "VITE_SUPABASE_URL",
-  "REACT_APP_SUPABASE_URL",
-  "SUPABASE_URL",
-);
-const supabaseAnonKey = getEnvVar(
-  "VITE_SUPABASE_ANON_KEY",
-  "REACT_APP_SUPABASE_ANON_KEY",
-  "SUPABASE_ANON_KEY",
-);
+const supabaseUrl =
+  ENV.VITE_SUPABASE_URL || ENV.REACT_APP_SUPABASE_URL || ENV.SUPABASE_URL;
+const supabaseAnonKey =
+  ENV.VITE_SUPABASE_ANON_KEY ||
+  ENV.REACT_APP_SUPABASE_ANON_KEY ||
+  ENV.SUPABASE_ANON_KEY;
 
 if (!supabaseUrl || !supabaseAnonKey) {
   // Provide a visible but non-blocking error in the console for missing vars


### PR DESCRIPTION
## Summary
- fix supabase initialization by aggregating env variables into a single object to avoid missing `process` polyfill

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*
- `npm test -- --watchAll=false` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_688f1ecc496c83229f59bd0c60b4732a