### PR TITLE
fix: robust supabase env lookup

### DIFF
--- a/frontend/src/lib/supabase.js
+++ b/frontend/src/lib/supabase.js
@@ -2,29 +2,38 @@
 import { createClient } from "@supabase/supabase-js";
 
 /**
- * Collect all available environment variables into a single object.
+ * Helper to resolve an environment variable from a variety of sources.
  *
- * `process.env` is inlined by bundlers such as Create React App/webpack, so we
- * grab it once here and then perform dynamic lookups on the resulting object.
- * This avoids relying on a runtime `process` polyfill, which is often missing
- * in browser builds and was the reason variables appeared as `undefined`.
+ * In development the values may come from `process.env` (CRA/webpack),
+ * `import.meta.env` (Vite) or a custom global such as `window.env` used in
+ * production deployments.  The lookup is performed dynamically at runtime so
+ * the code works across different build tools without requiring a `process`
+ * polyfill in the browser.
  */
-const ENV = {
-  ...(typeof import.meta !== "undefined" && import.meta.env
-    ? import.meta.env
-    : {}),
-  ...(typeof process !== "undefined" && process.env ? process.env : {}),
-  ...(typeof globalThis !== "undefined" && globalThis.env ? globalThis.env : {}),
-};
+function getEnvVar(name) {
+  if (typeof import.meta !== "undefined" && import.meta.env && name in import.meta.env) {
+    return import.meta.env[name];
+  }
+  if (typeof process !== "undefined" && process.env && name in process.env) {
+    return process.env[name];
+  }
+  if (typeof globalThis !== "undefined" && globalThis.env && name in globalThis.env) {
+    return globalThis.env[name];
+  }
+  return undefined;
+}
 
 // Attempt to retrieve variables using multiple possible prefixes so it works
-// with Create React App (REACT_APP_), Vite (VITE_) and generic names
+// with Create React App (REACT_APP_), Vite (VITE_) and generic names.
 const supabaseUrl =
-  ENV.VITE_SUPABASE_URL || ENV.REACT_APP_SUPABASE_URL || ENV.SUPABASE_URL;
+  getEnvVar("VITE_SUPABASE_URL") ||
+  getEnvVar("REACT_APP_SUPABASE_URL") ||
+  getEnvVar("SUPABASE_URL");
+
 const supabaseAnonKey =
-  ENV.VITE_SUPABASE_ANON_KEY ||
-  ENV.REACT_APP_SUPABASE_ANON_KEY ||
-  ENV.SUPABASE_ANON_KEY;
+  getEnvVar("VITE_SUPABASE_ANON_KEY") ||
+  getEnvVar("REACT_APP_SUPABASE_ANON_KEY") ||
+  getEnvVar("SUPABASE_ANON_KEY");
 
 if (!supabaseUrl || !supabaseAnonKey) {
   // Provide a visible but non-blocking error in the console for missing vars


### PR DESCRIPTION
## Summary
- improve Supabase env var resolution across build systems
- construct client only when URL and key are found

## Testing
- `cd frontend && npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_688f22ac26408322a5e801d69d61aa2f